### PR TITLE
CodeSniffer: print installed coding standards to stderr to allow pipelining with cs2pr

### DIFF
--- a/bin/codesniffer
+++ b/bin/codesniffer
@@ -37,7 +37,7 @@ else
 fi
 
 # Show installed coding standards
-${DIR}/phpcs -i
+${DIR}/phpcs -i 1>&2
 
 # Run sniffing
 if [ -z "$1" ]; then


### PR DESCRIPTION
Fixes https://github.com/contributte/psr7-http-message/actions/runs/6679077912/job/18150792275?pr=37